### PR TITLE
Switch from 2GB RAM to 4GB RAM

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,6 @@ docker-push:
 # Starts a fly machine for ci
 run *args:
   #!/bin/bash -eux
-  just docker-push
   fly m run \
     --region iad \
     --cpus 8 \
@@ -28,7 +27,7 @@ run *args:
 
 update id *args:
   #!/bin/bash -eux
-  just docker-push
   fly m update {{id}} \
-    --size shared-cpu-8x \
+    --cpus 8 \
+    --memory 4096 \
     {{args}}

--- a/Justfile
+++ b/Justfile
@@ -21,7 +21,8 @@ run *args:
   just docker-push
   fly m run \
     --region iad \
-    --size shared-cpu-8x \
+    --cpus 8 \
+    --memory 4096 \
     --volume ci:/vol \
     registry.fly.io/hapsoc-ci:latest {{args}}
 


### PR DESCRIPTION
We used to be on performance-8cpu, now we're on the shared equivalent and it defaults to 2G which OOMs some of the time and may have explained GHA flakiness on hapsoc/ktls